### PR TITLE
Separate Services into their own section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a list of tools, software & other resources related to the Internet Rela
   - [Self-hosted](#self-hosted)
   - [Hosted](#hosted)
 - [Daemons](#daemons)
+- [Services](#services)
 - [Bots](#bots)
 - [Frameworks](#frameworks)
   - [Bridges](#bridges)
@@ -86,11 +87,16 @@ This is a list of tools, software & other resources related to the Internet Rela
 
 - [ircd.js](https://github.com/alexyoung/ircd.js) - server will allow clients to connect, join channels, change topics; basic stuff
 - [InspIRCd](http://www.inspircd.org) - modular, stable, written from scratch ([source](https://github.com/inspircd/inspircd))
-- [Atheme](http://atheme.net) - legacy set of services designed for large networks with high scalability requirements ([source](https://github.com/atheme/atheme))
 - [miniircd](https://github.com/jrosdahl/miniircd) - very simple and limited
 - [ngIRCd](https://ngircd.barton.de) - portable and lightweight for small or private networks ([source](https://github.com/ngircd/ngircd))
-- [anope](http://anope.org) - designed for flexibility and ease of use ([source](https://github.com/anope/anope))
 - [Hulk](https://github.com/chrisdone/hulk) - intended for private business use or hobby work `Haskell`
+
+### Services
+
+*Used to provide user accounts and bots like NickServ/ChanServ to your network.
+
+- [Atheme](http://atheme.net) - designed for large networks with high scalability requirements ([source](https://github.com/atheme/atheme))
+- [anope](http://anope.org) - designed for flexibility and ease of use ([source](https://github.com/anope/anope))
 
 ### Bots
 


### PR DESCRIPTION
Since you use a daemon and an IRC services package together, I think it makes sense to separate them out and list them in a separate section. I left the "legacy" language out of Atheme's description since as far as I know they're running strong these days, and it makes their entry more consistent with anope's