### PR TITLE
Add BIP IRC Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This is a list of tools, software & other resources related to the Internet Rela
 - [TapChat](http://tapchatapp.com) - modern IRC ([source](https://github.com/tapchat/tapchat))
   - [Android App](https://github.com/tapchat/tapchat-android) - source only `Java`
 - [TheLounge](https://thelounge.github.io/) - responsive, self-hosted & support for multiple users ([source](https://github.com/thelounge/lounge), [demo](https://demo.thelounge.chat)) `JavaScript` `Node.js` `Web`
+- [BIP IRC Proxy](https://bip.milkypond.org/) - Lightweight Open Source IRC proxying, always online, multiple users/networks, logging and multi-client backlogging, TLS, password/SSL cert authentication, IRC admin interface, Debian packaged, recursive acronym ! ([source](https://projects.duckcorp.org/projects/bip/repository)) `C`
 
 ### Daemons
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This is a list of tools, software & other resources related to the Internet Rela
 - [TapChat](http://tapchatapp.com) - modern IRC ([source](https://github.com/tapchat/tapchat))
   - [Android App](https://github.com/tapchat/tapchat-android) - source only `Java`
 - [TheLounge](https://thelounge.github.io/) - responsive, self-hosted & support for multiple users ([source](https://github.com/thelounge/lounge), [demo](https://demo.thelounge.chat)) `JavaScript` `Node.js` `Web`
-- [BIP IRC Proxy](https://bip.milkypond.org/) - Lightweight Open Source IRC proxying, always online, multiple users/networks, logging and multi-client backlogging, TLS, password/SSL cert authentication, IRC admin interface, Debian packaged, recursive acronym ! ([source](https://projects.duckcorp.org/projects/bip/repository)) `C`
+- [BIP IRC Proxy](https://bip.milkypond.org/) - Always online, lightweight and secure Open Source IRC proxying with backlogging ([source](https://projects.duckcorp.org/projects/bip/repository)) `C`
 
 ### Daemons
 


### PR DESCRIPTION
I'm the co-author of BIP, it's been designed to be lightweight (in simple C) but fully functionnal for always online multiple users IRC proxying, for people who want to have their logs kept safe, and multi-client backlogging, TLS-secured with irssi-compatible password auth and optional client SSL certificate authentication. It can be managed within the administrator's IRC clients. It's Debian packaged. And last but not least, it has a recursive acronym, like all good Open Source projects !