### PR TITLE
IrcII

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ IRC (Internet Relay Chat) is an open source protocol that can be used for multi-
 - [IRC for Android™](https://www.countercultured.net/android/) - Android/Chrome OS client for power users, with ZNC built-ins, notification logic, reliable DCC, keybinds for hardware keyboards, etc. `Android` `ChromeOS`
 - [Iridium](https://appcenter.elementary.io/com.github.avojak.iridium/) - Friendly IRC client built in Vala and GTK, designed for elementary OS. ([source](https://github.com/avojak/iridium)) `Linux`
 - [Goguma](https://sr.ht/~emersion/goguma/) - An IRC client for mobile devices, from the creator of soju. `Android` `Linux`
+- [IrcII](http://www.eterna23.net/ircii/) - Initially released in the late 1989, it is the oldest IRC client still maintained. [screenshot](https://en.wikipedia.org/wiki/File:Ircii.png)) `Linux` `FreeBSD` `*BSD` `MacOS`
 
 <!--lint ignore double-link-->
 *More? Clients that include bouncers are found [below](#bouncers).*


### PR DESCRIPTION
IrcII seems to be the oldest irc client and still maintened (latest release by january 2024). Would be nice to have it listed